### PR TITLE
Browser console logging for goatee

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ if (typeof exports === 'object' && typeof define !== 'function') {
 }
 
 define(function(require, exports, module) {
+	
+	var CircularJSON = require('/sv_local/node_modules/npm/circular-json/');
+
 	(function() {
 		var openChar = "Ͼ";
 		var closeChar = "Ͽ";
@@ -423,7 +426,14 @@ define(function(require, exports, module) {
 			
 			console.log.apply(console, arguments);
 		}
-		
+
+		Helpers.prototype.console = function(arg1) {
+			var self = this;
+			var template = "<script>console.log({{output}});</script>";
+
+			return fill(template, { output : CircularJSON.stringify(arg1, null, null, true).replace(/>/g, "&lt;") });
+		}
+
 		Helpers.prototype.setVar = function(arg1, arg2) {
 			var self = this;
 			

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ define(function(require, exports, module) {
 						if (context.tags[i].command === "" || typeof myData !== "string") {
 							returnArray.push(myData)
 						} else {
-							returnArray.push(myData.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'));
+							returnArray.push(myData.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'));
 						}
 					} else if (typeof myData.template != "undefined" && typeof myData.data != "undefined") {
 						/*** passing a template and data structure ***/

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ define(function(require, exports, module) {
 						if (context.tags[i].command === "" || typeof myData !== "string") {
 							returnArray.push(myData)
 						} else {
-							returnArray.push(myData.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'));
+							returnArray.push(myData.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'));
 						}
 					} else if (typeof myData.template != "undefined" && typeof myData.data != "undefined") {
 						/*** passing a template and data structure ***/
@@ -431,7 +431,7 @@ define(function(require, exports, module) {
 			var self = this;
 			var template = "<script>console.log({{output}});</script>";
 
-			return fill(template, { output : CircularJSON.stringify(arg1, null, null, true).replace(/>/g, "&lt;") });
+			return fill(template, { output : CircularJSON.stringify(arg1, null, null, true).replace(/\</g, "&lt;") });
 		}
 
 		Helpers.prototype.setVar = function(arg1, arg2) {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
 	"name" : "goatee",
 	"description" : "Powerful yet simple templating system with Mustache style syntax and many more features. Works in node and browser with requirejs.",
 	"author" : "Owen Allen <owenallenaz@gmail.com>",
-	"version" : "1.1.4",
+	"version" : "1.1.5",
 	"devDependencies" : {
 		"mocha" : "*"
+	},
+	"dependencies" : {
+		"circular-json" : "*"
 	},
 	"engines" : { "node" : ">=0.10.x" },
 	"scripts" : {

--- a/testing/index.test.js
+++ b/testing/index.test.js
@@ -391,6 +391,10 @@ describe(__filename, function() {
 			// output dynamically declared partial
 			assert.equal(goatee.fill("{{+test}}{{foo}}{{/}}{{~partial('test')}}", {}), "{{foo}}");
 		});
+
+		it("should execute console helper", function() {
+			assert.equal(goatee.fill("{{~console(data)}}", { foo : "something", bar : [1] }), '<script>console.log({"foo":"something","bar":[1]});</script>');
+		});
 		
 		it("should execute log helper", function() {
 			var result;


### PR DESCRIPTION
Adding this change will allow developers to easy console log their data into their browser and not the stdio terminal.  This has a number of advantages such as the ease of being able to all objects and items in the dump with the ability to drill down into arrays and objects using the native json parser in a browsers console.  http://screencast.com/t/xPyXhVE0SlcV  It is also nicer and quicker to reference, without having to keep the terminal window up and open to view your data.  The data that is dumped in the stdio is hard to read and gets very confusing not having the ability to collapse arrays and objects.

Using this new feature is extremely simple and especially if you are already familiar with using {{~log(data)}}, simply use the new function {{~console(data)}} and you can instantly view your results in the browsers console window.

This comes with one side affect that I was not able to fix, since I am requiring a new external package "circular-json" which comes from npm inside the goatee script, requirejs do not seem to like the script being loaded like that, I'm sure it is because I just do not understand requirejs enough to fix this problem, possibly a very easy fix of just registering this new package. But since requirejs rejects this load, the CMS itself has javascript errors which makes the rest of the javascript fail to load. http://screencast.com/t/Ty8ZjvWig8Dl

If this problem can be overcome, I feel this is a decent solution for now, for adding the ability of writing our data into the browsers console, and not have to deal with the stdio terminal.

The data json returned from serverside node, needs to be converted to a string, so that we are then able to console.log(data) that information.  We also need to consider the possibility of HTML being inside our json string, if that is the case then since we are converting the json object into a string format, then placing that onto the page it will render the html and display it on the page. Thus we need to perform a regex replace looking for any less than symbols and convert them into something else (&lt;) to prevent the browser from rendering this as html.

Also keeping inline with the idea of testing your features and additions, I wrote a test to ensure this new method worked accordingly. http://screencast.com/t/sBkNrB7aQ

On a final note, the reason for adding a new package "circular-json" is due to the fact that some data such as the navigation data returns circular references.  These circular references break the normal JSON.Stringify() function, since it can not handle these types of references we require this new package to be included.

If you have any questions or would like anymore information on how this can be used or implemented, please contact me: jschwarz@simpleviewinc.com.
